### PR TITLE
Changes to the Naming Conventions

### DIFF
--- a/docs/naming-conventions.md
+++ b/docs/naming-conventions.md
@@ -5,51 +5,56 @@ title: Naming Conventions
 
 # Naming Conventions
 
-This document summarizes MontageJS-specific naming conventions and recommendations for modules, components, and CSS classes. Please refer to these conventions when creating MontageJS packages or contributing to the MontageJS framework.
+This document summarizes MontageJS-specific naming conventions and recommendations for packages, components, and CSS classes. Please refer to these conventions when creating MontageJS packages or contributing to the MontageJS framework.
 
-## Rationale
-We chose these conventions for the following reasons:
+## Packages
 
-* To reduce the effort to read and understand the markup structure of our source code.
-* To increase code usability because you can double-click each part of the code to quickly select and edit it. (Try it: `montage-InputRange-thumb` versus `montage_InputRange_thumb`.)
-* To avoid name collisions due to multiple selectors.
+All package names are written in lowercase letters or numbers and delimited by dashes (for example, child-package).
 
-## Modules
-
-All module and package names are written in lowercase letters or numbers and delimited by dashes (for example, child-package).
-
-## Components
+## Components (.reel)
 User interface components are stored in the ui directory of your MontageJS project and identified by a .reel extension. 
 
 The following naming conventions apply for `.reel` directories:
 
 * Component names are always spelled in lowercase letters.
-* If an official W3C HTML element exists, the component's name matches the name of that element; for example, `button` (`button.reel`) for a `<button>`.
-* If an official HTML equivalent does not exist, assign a name that captures the function or meaning of the component; for example, `toggle-switch`.
-* Input elements follow a dash-delimited `"element-type"` pattern; for example, `input-range`, `input-radio`, or `input-color`.
+* If the name uses multiple words, follow a dash-delimited `"word-word"` pattern; for example, `radio-button.reel`, or `text-field.reel`.
 
 
 ## CSS Classes
 
-CSS class names follow a dash-delimited `org-Component` and `org-Component-childElement` pattern. For example, for the progress bar it would be: `montage-Progress` and `montage-Progress-bar`.
+CSS class names follow a dash-delimited `package-Component` and `package-Component-childElement` pattern. For variations and states, double dash is used. For example, for the Matte Progress component it would be:
+
+```css
+.matte-Progress          /* package + Component */
+.matte-Progress-bar      /* package + Component + child element */
+.matte-Progress--small   /* variation */
+.matte-Progress--loading /* state */
+```
 
 More specifically, the following conventions apply:
 
-1. All CSS classes are prefixed with **montage** + **dash**: `montage-`.
-2. Component names follow the namespace identifier (`montage-`) and always start with an uppercase letter; for example, `montage-Button`. 
+1. All CSS classes are **name-spaced** with **package** + **dash**, like `montage-`, `digit-`, `matte-` etc.
+2. Followed by the **Component** name that always starts with an uppercase letter; for example a button component would be: `digit-Button` and used as: 
 
     ```
-    <button data-montage-id "button" class="montage-Button">
+    <button data-montage-id="button" class="digit-Button">
     ```
 
-    If a component name consists of more than one word, each new word also starts with an uppercase letter, a convention commonly referred to as **upper camel case** ("CamelCaps") formatting; for example, `montage-Button`, `montage-InputRange`.
+    If a component name consists of more than one word, each new word also starts with an uppercase letter, a convention commonly  referred to as **upper camel case** ("CamelCaps") formatting; for example, `montage-InputRange`.
     
-3. Composite components (components with children) follow this convention:
+3. **Composite components** (components with children) follow this convention:
+    * If a component has a **child element**, the child's name is written in lowercase (to signal the distinction between parent and child) and follows the component’s name separated by a dash; for example, `digit-Slider-thumb`.
+    * If a child element consists of concatenated words, its name is written in lower camelCase; for example, `digit-Slider-thumbWithSpikyEars`.
+    * If a component has multiple levels of child elements, each child can be separated from the other by a dash; for example, `digit-Slider-thumb-nobs-centerNob`. This is not required in all cases as the class name would become too long. Only use if it makes sense.
 
-    If a component has a **child element**, the child's name is written in lowercase (to signal the distinction between parent and child) and follows the component's name separated by a dash; for example, `montage-InputRange-thumb`. Be sure to use the same name for children as the native pseudo (Shadow DOM) elements if known; for example: -webkit-progress-**bar**. Angelina Fabbro put together a nice reference [list](https://gist.github.com/3759334) of pseudo element selectors used in WebKit.
-    * If a child element consists of concatenated words, its name is written in lower camelCase; for example, `montage-InputRange-thumbWithSpikyEars`.
-    * If a component has multiple levels of child elements, each child is separated from the other by a dash; for example, `montage-InputRange-thumb-nobs-centerNob`.
+4. **Variations** If a component offers variations, a double-dash is used; for example: `digit-Button--primary`, `digit-Slider--vertical`.
 
-        **Note:** There is **no limit** as to how many levels of child elements can be used, but if the whole CSS class becomes too long, it might be a good idea to **break** it into subcomponents.
+5. **States** If a component uses different states, also a double-dash is used; for example: `digit-Slider--dragging`, `matte-Button--pressed`.
 
-    * If a class name represents a **state** or a **variation**, a double-dash is used; for example, (states) `montage-InputRange--dragging`, `montage-Button--pressed` or (variations) `montage-Button--big`, `montage-Button--primary`.
+### Rationale
+These CSS naming conventions are similar to [BEM](http://bem.info/method/). But the syntax got adapted for the following reasons:
+
+* Name-spacing it with the package avoids name collisions when packages are getting mixed.
+* Not using underscores "_" increases usability because you can double-click each part to quickly select and edit it. (Try it: `digit-Slider-thumb` versus `digit_Slider_thumb`.)
+* Using upper "CamelCase" for components highlights component/child relationship.
+* Using "camelCase" for multiword names increases readability but still keeps each part grouped together.

--- a/docs/naming-conventions.md
+++ b/docs/naming-conventions.md
@@ -5,11 +5,13 @@ title: Naming Conventions
 
 # Naming Conventions
 
-This document summarizes MontageJS-specific naming conventions and recommendations for packages, components, and CSS classes. Please refer to these conventions when creating MontageJS packages or contributing to the MontageJS framework.
+This document summarizes MontageJS-specific naming conventions and recommendations for modules, components, and CSS classes. Please refer to these conventions when creating MontageJS packages or contributing to the MontageJS framework.
 
-## Packages
 
-All package names are written in lowercase letters or numbers and delimited by dashes (for example, child-package).
+## Modules
+
+All module and package names are written in lowercase letters or numbers and delimited by dashes (for example, `child-package`).
+
 
 ## Components (.reel)
 User interface components are stored in the ui directory of your MontageJS project and identified by a .reel extension. 


### PR DESCRIPTION
Some changes to the naming convention:
- The requirement that **all** child elements of a component need to be separated with a dash, like `montage-InputRange-thumb-nobs-centerNob`, is removed. Initially the idea was so that you can see the markup structure without looking at the HTML. It was a good idea and worked well for Digit. But that's because Digit still only has simple components with not a lot of children. For more complex apps it didn't really scale. The class names became too long and it wasn't really flexible to move stuff around. It's still in there, but just optional if it makes sense.
- Removed W3C naming scheme, since Digit started to use their own one.
- Changed "module" to "package". Haven't heard "module" being used with Montage. Also so that it matches the CSS section.
