### PR TITLE
Remove unused variable in bindings examples

### DIFF
--- a/docs/montagejs-examples.md
+++ b/docs/montagejs-examples.md
@@ -20,7 +20,7 @@ The following components are pre-built MontageJS components.
 #### Text
 * [Hello World](http://montagejs.github.io/mfiddle/#!/5904314)
 * [Set text programmatically](http://montagejs.github.io/mfiddle/#!/5904331)
-* [Set text with a binding](http://montagejs.github.io/mfiddle/#!/5904335)
+* [Set text with a binding](http://montagejs.github.io/mfiddle/#!/6343006)
 
 #### Page Controls
 * [Simple repetition](http://montagejs.github.io/mfiddle/#!/5904339)


### PR DESCRIPTION
http://montagejs.github.io/mfiddle/#!/5904335

component.js:6

``` javascript
            var text = this.templateObjects.text,
```

`text` is unused variable. Shouldn’t be here.

Fixed mfiddle: http://montagejs.github.io/mfiddle/#!/6343006
