### PR TITLE
JSDoc: fix spacing for details table

### DIFF
--- a/_build/jsdoc/template/static/styles/jsdoc-default.css
+++ b/_build/jsdoc/template/static/styles/jsdoc-default.css
@@ -247,6 +247,7 @@ h6
 	border-left: 2px solid #DDD;
 	padding-right: 0;
 	white-space: nowrap;
+	width: 1em;
 }
 #api .dummy {
 	padding-left: 0;

--- a/api/styles/jsdoc-default.css
+++ b/api/styles/jsdoc-default.css
@@ -247,6 +247,7 @@ h6
 	border-left: 2px solid #DDD;
 	padding-right: 0;
 	white-space: nowrap;
+	width: 1em;
 }
 #api .dummy {
 	padding-left: 0;


### PR DESCRIPTION
Before:
![before](https://f.cloud.github.com/assets/55838/1392084/4d18e48e-3c06-11e3-94f7-86c32a3bac5d.png)

After:
![after](https://f.cloud.github.com/assets/55838/1392083/454ad046-3c06-11e3-86e2-c86d2f941f42.png)
