### PR TITLE
Redirects

### DIFF
--- a/404.html
+++ b/404.html
@@ -21,14 +21,38 @@ title: 404 - MontageJS
 </section>
 
 <script type="text/javascript">
+    
     var path = window.location.pathname;
+    
     // sets the title so we know which URLs are broken
     document.title = "404 - " + path;
-
+    
+    // Old API Docs
     var oldApiDocMatcher = /\/apis\/([^.]*).html/
     var oldApiDocMatch = path.match(oldApiDocMatcher);
-
+    
+    // Redirects List
+    var redirects = [
+        [ '/test.html', '/docs/montagejs-setup.html' ],
+        [ '/docs/test.html', '/docs/draw-cycle.html' ],
+        [ '/test', '/docs/frb.html' ]
+    ];
+    
+    // Redirect
     if (oldApiDocMatch) {
         window.location = "/api/" + oldApiDocMatch[1] + ".html";
+    } else {
+        var redirectTo;
+        for (var i = 0; i < redirects.length; i++) {
+            console.log(redirects[i][0]);
+            if (redirects[i][0] == path) {
+                redirectTo = redirects[i][1];
+                break;
+            }
+        }
+        if (redirectTo) {
+            window.location = redirectTo;
+        }
     }
+        
 </script>

--- a/404.html
+++ b/404.html
@@ -31,28 +31,19 @@ title: 404 - MontageJS
     var oldApiDocMatcher = /\/apis\/([^.]*).html/
     var oldApiDocMatch = path.match(oldApiDocMatcher);
     
-    // Redirects List
-    var redirects = [
-        [ '/test.html', '/docs/montagejs-setup.html' ],
-        [ '/docs/test.html', '/docs/draw-cycle.html' ],
-        [ '/test', '/docs/frb.html' ]
-    ];
-    
-    // Redirect
     if (oldApiDocMatch) {
         window.location = "/api/" + oldApiDocMatch[1] + ".html";
-    } else {
-        var redirectTo;
-        for (var i = 0; i < redirects.length; i++) {
-            console.log(redirects[i][0]);
-            if (redirects[i][0] == path) {
-                redirectTo = redirects[i][1];
-                break;
-            }
-        }
-        if (redirectTo) {
-            window.location = redirectTo;
-        }
+    }
+    
+    // Redirect List
+    var redirects = {
+        '/test.html': '/docs/montagejs-setup.html',
+        '/docs/test.html': '/docs/draw-cycle.html',
+        '/test': '/docs/frb.html'
+    };
+    
+    if (redirects.hasOwnProperty(path)) {
+        window.location = redirects[path];
     }
         
 </script>


### PR DESCRIPTION
This checks a `404` against a list of redirects and if there is a match it forwards to the new location. That way we could get rid of all the other redirect html files that start cluttering up everywhere.

Also see benefits in #34. Might also solve #62.
- In this PR I just added 3 tests to the list, if the script is ok, I'll add the real ones and remove the html files.
