### PR TITLE
Yellow vs Grey code

### DIFF
--- a/stylesheets/pages.css
+++ b/stylesheets/pages.css
@@ -243,9 +243,9 @@
 code {
     padding: 0 4px;
     border-radius: 4px;
-    border: 1px solid hsl(60, 20%, 85%);
-    background-color: hsl(50,100%,98%);
-    color: hsl(50,20%,40%);
+    border: 1px solid hsl(0, 0%, 88%);
+    background-color: hsl(0, 0%, 98%);
+    color: hsl(0, 0%, 50%);
 }
 
 code[data-lang]:after {
@@ -260,7 +260,7 @@ code[data-lang]:after {
     line-height: 1.6;
     text-transform: uppercase;
     font-family: 'Open Sans', sans-serif;
-    color: hsl(50,20%,60%);
+    color: hsl(0,0%,66%);
     border-radius: 0 5px;
     border-left: 1px solid hsla(0, 0%, 0%, 0.05);
     border-bottom: 1px solid hsla(0, 0%, 0%, 0.05);
@@ -280,11 +280,11 @@ code[data-lang]:after {
     padding: 20px;
     font-size: .9em;
     line-height: 1.3;
-    color: hsl(60, 15%, 36%);
     border-radius: 6px;
-    border: 1px solid hsl(60, 20%, 86%);
+    border: 1px solid hsl(0, 0%, 88%);
+    background-color: hsl(0, 0%, 98%);
+    color: hsl(0, 0%, 50%);
     box-shadow: inset 0 1px 3px hsla(0, 0%, 0%, 0.04), 0 1px 0 hsla(0, 0%, 100%, 0.6);
-    background-color: hsl(50,100%,98%);
 }
 
 .highlight pre > code,

--- a/stylesheets/pages.css
+++ b/stylesheets/pages.css
@@ -241,10 +241,6 @@
 /* Code ----------------------------------------- */
 
 code {
-    padding: 0 4px;
-    border-radius: 4px;
-    border: 1px solid hsl(0, 0%, 88%);
-    background-color: hsl(0, 0%, 98%);
     color: hsl(0, 0%, 50%);
 }
 


### PR DESCRIPTION
:warning: More opinions needed before merging :warning: 

Replaces the yellowish background of `inline code` and

```
Code Blocks
```

with a light grey background:

![grey](https://f.cloud.github.com/assets/378023/1670557/3e868646-5c9b-11e3-8108-7228658468db.png)

Current (yellow) vs new (grey):

![compare](https://f.cloud.github.com/assets/378023/1670561/4aafc7ac-5c9b-11e3-8962-01f59caa6741.png)
## Opinions

@segphault: Main voice behind removing yellow

@mikokim: Would like `inline code` without the border/background and only monospaced font. It's for easier scanning of the text.

@simurai Likes the yellow since it matches the syntax highlighting. Also makes it easier to see what is code and what is text.

Anyone more preferences? 
