### PR TITLE
using enterDocument to add event listeners

### DIFF
--- a/docs/event-handling.md
+++ b/docs/event-handling.md
@@ -246,7 +246,7 @@ exports.Employee = Montage.create(Montage, {
             console.log("fullName changed to " + this.fullName);
         }
     },
-    deserializedFromTemplate: {
+    enterDocument: {
         value: function() {
             // Create a change@ event listener, 
             this.addEventListener("change@fullName", this);
@@ -279,7 +279,7 @@ exports.Employee = Montage.create(Montage, {
             console.log("fullName changed to " + this.fullName);
         }
     },
-    deserializedFromTemplate: {
+    enterDocument: {
         value: function() {
             Montage.addDependencyToProperty(this, "firstName", "fullName");
             Montage.addDependencyToProperty(this, "lastName", "fullName");


### PR DESCRIPTION
I tried deserializedFromTemplate and enterDocument to add event listeners in a rather complex case, enterDocument seemed to work better. not sure if there is something else in here that depends on being in the deserializedFromTemplate?
