### PR TITLE
Add context to objects docs

### DIFF
--- a/docs/montagejs-objects.md
+++ b/docs/montagejs-objects.md
@@ -18,37 +18,37 @@ For a succinct comparison, the following examples A and B are equivalent:
 ### Class Declaration Example A
 
 ```javascript
-function Constructor() {
-    ParentConstructor.call(this);
+function Penguin() {
+    Bird.call(this);
 }
 
-Constructor.prototype = Object.create(ParentConstructor.prototype);
+Penguin.prototype = Object.create(Bird.prototype);
 
-Constructor.prototype.constructor = Constructor;
+Penguin.prototype.constructor = Penguin;
 
-Constructor.prototype.method = function () {
-    return ParentConstructor.prototype.method.call(this);
+Penguin.prototype.method = function () {
+    return Bird.prototype.method.call(this);
 };
 
-Object.defineProperty(Constructor.prototype, "property", {
+Object.defineProperty(Penguin.prototype, "habitat", {
     get: function () {
-        return this._property;
+        return this._habitat;
     },
     set: function (value) {
-        this._property = value;
+        this._habitat = value;
     }
 });
 
-Constructor.staticMethod = function () {
+Penguin.staticMethod = function () {
 };
 ```
 
 ### Class Declaration Example B
 
 ```javascript
-var Constructor = ParentConstructor.specialize({
+var Penguin = Bird.specialize({
     constructor: {
-        value: function Constructor() {
+        value: function Penguin() {
             this.super();
         }
     },
@@ -58,12 +58,12 @@ var Constructor = ParentConstructor.specialize({
         },
         enumerable: true
     },
-    property: {
+    habitat: {
         get: function () {
-            return this._property;
+            return this._habitat;
         },
         set: function (value) {
-            this._property = value;
+            this._habitat = value;
         }
     }
 }, {

--- a/docs/montagejs-objects.md
+++ b/docs/montagejs-objects.md
@@ -13,7 +13,9 @@ next-page: data-binding
 
 MontageJS provides a thin veneer over the JavaScript object model: Types are represented by constructor functions. Constructor functions have a `prototype`. The `prototype` has a `constructor`. `instanceof` and `new` work as you would expect.
 
-For a succinct comparison, the following examples are equivalent:
+For a succinct comparison, the following examples A and B are equivalent:
+
+### Class Declaration Example A
 
 ```javascript
 function Constructor() {
@@ -40,6 +42,8 @@ Object.defineProperty(Constructor.prototype, "property", {
 Constructor.staticMethod = function () {
 };
 ```
+
+### Class Declaration Example B
 
 ```javascript
 var Constructor = ParentConstructor.specialize({

--- a/docs/montagejs-objects.md
+++ b/docs/montagejs-objects.md
@@ -26,8 +26,8 @@ Penguin.prototype = Object.create(Bird.prototype);
 
 Penguin.prototype.constructor = Penguin;
 
-Penguin.prototype.method = function () {
-    return Bird.prototype.method.call(this);
+Penguin.prototype.fly = function () {
+    return Bird.prototype.fly.call(this);
 };
 
 Object.defineProperty(Penguin.prototype, "habitat", {
@@ -52,7 +52,7 @@ var Penguin = Bird.specialize({
             this.super();
         }
     },
-    method: {
+    fly: {
         value: function () {
             return this.super();
         },

--- a/docs/montagejs-objects.md
+++ b/docs/montagejs-objects.md
@@ -15,7 +15,7 @@ MontageJS provides a thin veneer over the JavaScript object model: Types are rep
 
 For a succinct comparison, the following examples A and B are equivalent:
 
-### Class Declaration Example A
+### Example A
 
 ```javascript
 function Penguin() {
@@ -43,7 +43,7 @@ Penguin.staticMethod = function () {
 };
 ```
 
-### Class Declaration Example B
+### Example B
 
 ```javascript
 var Penguin = Bird.specialize({

--- a/docs/montagejs-objects.md
+++ b/docs/montagejs-objects.md
@@ -15,7 +15,7 @@ MontageJS provides a thin veneer over the JavaScript object model: Types are rep
 
 For a succinct comparison, the following examples A and B are equivalent:
 
-### Example A
+### Example A: JavaScript (ECMAScript 5)
 
 ```javascript
 function Penguin() {
@@ -43,7 +43,7 @@ Penguin.staticMethod = function () {
 };
 ```
 
-### Example B
+### Example B: MontageJS
 
 ```javascript
 var Penguin = Bird.specialize({


### PR DESCRIPTION
if someone has never seen property descriptors, the montage syntax looks exotic.

```
    get: function () {
        return this._property;
    },
    set: function (value) {
        this._property = value;
    }
```

by adding some context to the examples, maybe it will seem less exotic...
