### PR TITLE
Added chrome app instructions for loading serialization

### DIFF
--- a/docs/serialization-format.md
+++ b/docs/serialization-format.md
@@ -373,3 +373,47 @@ Montage uses the browser's native JSON parsing APIs to parse the serialization b
 * Matching brackets. Obviously, each open bracket must have a matching close bracket.
 
 Montage reports any formatting errors in the console when you run the application.
+
+
+## Loading Declaration JSON in Chrome Apps
+
+Chrome apps and Chrome extensions [forbid inline script tags](http://developer.chrome.com/extensions/contentSecurityPolicy.html#JSExecution). Instead, you can load your component's declaration using a link tag.
+
+`person.html`
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="stylesheet" type="text/css" href="person.css">
+    <link rel="serialization" type="text/montage-serialization" href="person.json">
+</head>
+<body>
+    <div data-montage-id="person" class="Person">
+        <input data-montage-id="firstName"></input>
+    </div>
+</body>
+</html>
+
+```
+
+`person.json`
+
+```javascript
+{
+    "owner": {
+        "properties": {
+            "element": {"#": "person"}
+        }
+    }
+},
+{
+   "firstName": {
+       "prototype": "digit/ui/text-field.reel",
+       "properties": {
+           "element": {"#": "firstName"}
+       }
+    }
+}
+
+```


### PR DESCRIPTION
You cant develop montage apps in a chrome extension without knowing how to load the serialization with out a script tag. 

This is a show stopper with a quick fix for devs who build chrome apps, or who are used to using chrome extensions to debug client side apps. 
- chrome content security policy will not execute inline script tags: http://developer.chrome.com/extensions/contentSecurityPolicy.html#JSExecution

more refs: 
- recommended frameworks which support csp:  http://developer.chrome.com/apps/app_frameworks.html#recommended
- other frameworks which support chrome csp: https://groups.google.com/a/chromium.org/forum/#!topic/chromium-extensions/Wyer5m3Y4tQ,  https://github.com/cesine/todomvc-for-chrome-extensions/issues?labels=&milestone=&page=1&state=closed
